### PR TITLE
Creating a section for sample Standard Redfish event

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9580,6 +9580,33 @@ curl -i POST \
 
 ```
 
+>**Sample response body**
+
+Here's a sample response returned for standard Redfish events at the destination.
+
+~~~
+{
+   "@odata.context":"/redfish/v1/$metadata#Event.Event",
+   "@odata.type":"#Event.v1_7_0.Event",
+   "Events":[
+      {
+         "EventId":"ffa39cd4-4d95-4296-9ffd-e67c1135e96f",
+         "EventTimestamp":"2022-02-01T16:40:35Z",
+         "EventType":"ResourceAdded",
+         "Message":"The resource has been created successfully.",
+         "MessageId":"ResourceEvent.1.2.0.ResourceAdded",
+         "OriginOfCondition":{
+            "@odata.id":"/redfish/v1/Managers/dd187ab4-310c-4be0-beeb-0412a6b00806.1"
+         },
+         "Severity":"OK"
+      }
+   ],
+   "Name":"Resource Event"
+}
+~~~
+
+
+
 ###  Creating event subscription with eventformat type - MetricReport
 
 If `EventFormatType` is empty, default value will be `Event`.
@@ -9707,8 +9734,6 @@ Content-Length:0 byte
 
 ```
 
- 
-
 >**Sample response header** \(HTTP 201 status\) 
 
 ```
@@ -9742,6 +9767,7 @@ Transfer-Encoding:chunked
 ```
 
 >**Sample response body** \(subtask\) 
+
 
 ```
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,6 +153,7 @@
 - [Events](#events)
   * [Viewing the event service root](#viewing-the-event-service-root)
   * [Creating an event subscription](#creating-an-event-subscription)
+    + [Sample event](#sample-event)
     + [Creating event subscription with eventformat type “MetricReport”](#creating-event-subscription-with-eventformat-type---metricreport)
   * [Submitting a test event](#submitting-a-test-event)
   * [Event subscription use cases](#event-subscription-use-cases)
@@ -9580,9 +9581,9 @@ curl -i POST \
 
 ```
 
->**Sample response body**
+### Sample event
 
-Here's a sample response returned for standard Redfish events at the destination.
+Here is a sample of standard Redfish event delivered to a destination.
 
 ~~~
 {


### PR DESCRIPTION
Add a new section for Standard Redfish events delivered to a destination, in the API readme